### PR TITLE
Add support for HTTPS proxying

### DIFF
--- a/src/sysward-agent.go
+++ b/src/sysward-agent.go
@@ -73,6 +73,11 @@ func GetHttpClient() http.Client {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		Dial:            dialTimeout,
 	}
+	if os.Getenv("HTTPS_PROXY") != "" {
+		proxyUrl, _ := url.Parse(os.Getenv("HTTPS_PROXY"))
+		tr.Proxy = http.ProxyURL(proxyUrl)
+	}
+
 	client := http.Client{Transport: tr}
 	return client
 }


### PR DESCRIPTION
Adds support for `HTTPS_PROXY` env param

Example to send everything through a http and https proxy (proxy server used here is mitmproxy):

`
http_proxy=http://192.168.5.100:8080/ HTTPS_PROXY=http://192.168.5.100:8080/ ./sysward 
`

lower case `http_proxy` must be used for apt to pick it up (`HTTP_PROXY`) does not work